### PR TITLE
Deploy single server

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ provider "aws" {
 resource "aws_instance" "ibrah-useast-1a" {
   ami           = "ami-40d28157"
   instance_type = "t2.micro"
+  vpc_security_group_ids = ["${aws_security_group.webserver.id}"]
 
   user_data = <<-EOF
               #!/bin/bash

--- a/main.tf
+++ b/main.tf
@@ -17,3 +17,14 @@ resource "aws_instance" "ibrah-useast-1a" {
     Name = "ibrah-useast-1a"
   }
 }
+
+resource "aws_security_group" "webserver" {
+  name = "webserver"
+
+  ingress {
+    from_port = 8080
+    to_port = 8080
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,12 @@ resource "aws_instance" "ibrah-useast-1a" {
   ami           = "ami-40d28157"
   instance_type = "t2.micro"
 
+  user_data = <<-EOF
+              #!/bin/bash
+              echo "Hello, World" > index.html
+              nohup busybox httpd -f -p 8080 &
+              EOF
+
   tags = {
     Name = "ibrah-useast-1a"
   }


### PR DESCRIPTION
Plan output:
```
  # aws_instance.ibrah-useast-1a must be replaced
-/+ resource "aws_instance" "ibrah-useast-1a" {
        ami                          = "ami-40d28157"
      ~ arn                          = "arn:aws:ec2:us-east-1:602951720456:instance/i-0aa497a7d9098b3bb" -> (known after apply)
      ~ associate_public_ip_address  = true -> (known after apply)
      ~ availability_zone            = "us-east-1b" -> (known after apply)
      ~ cpu_core_count               = 1 -> (known after apply)
      ~ cpu_threads_per_core         = 1 -> (known after apply)
      - disable_api_termination      = false -> null
      - ebs_optimized                = false -> null
        get_password_data            = false
      + host_id                      = (known after apply)
      ~ id                           = "i-0aa497a7d9098b3bb" -> (known after apply)
      ~ instance_state               = "running" -> (known after apply)
        instance_type                = "t2.micro"
      ~ ipv6_address_count           = 0 -> (known after apply)
      ~ ipv6_addresses               = [] -> (known after apply)
      + key_name                     = (known after apply)
      - monitoring                   = false -> null
      + network_interface_id         = (known after apply)
      + password_data                = (known after apply)
      + placement_group              = (known after apply)
      ~ primary_network_interface_id = "eni-0de918fbe09049450" -> (known after apply)
      ~ private_dns                  = "ip-172-31-44-243.ec2.internal" -> (known after apply)
      ~ private_ip                   = "172.31.44.243" -> (known after apply)
      ~ public_dns                   = "ec2-18-234-120-72.compute-1.amazonaws.com" -> (known after apply)
      ~ public_ip                    = "18.234.120.72" -> (known after apply)
      ~ security_groups              = [
          - "default",
        ] -> (known after apply)
        source_dest_check            = true
      ~ subnet_id                    = "subnet-2659097a" -> (known after apply)
        tags                         = {
            "Name" = "ibrah-useast-1a"
        }
      ~ tenancy                      = "default" -> (known after apply)
      + user_data                    = "c765373c563b260626d113c4a56a46e8a8c5ca33" # forces replacement
      ~ volume_tags                  = {} -> (known after apply)
      ~ vpc_security_group_ids       = [
          - "sg-c7346f9c",
        ] -> (known after apply)

      - credit_specification {
          - cpu_credits = "standard" -> null
        }

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + snapshot_id           = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      ~ root_block_device {
          ~ delete_on_termination = true -> (known after apply)
          ~ iops                  = 100 -> (known after apply)
          ~ volume_id             = "vol-0f275947ff089dfc5" -> (known after apply)
          ~ volume_size           = 8 -> (known after apply)
          ~ volume_type           = "gp2" -> (known after apply)
        }
    }

  # aws_security_group.webserver will be created
  + resource "aws_security_group" "webserver" {
      + arn                    = (known after apply)
      + description            = "Managed by Terraform"
      + egress                 = (known after apply)
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 8080
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 8080
            },
        ]
      + name                   = "webserver"
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + vpc_id                 = (known after apply)
    }

Plan: 2 to add, 0 to change, 1 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```
New dependency graph: 
```
https://dreampuf.github.io/GraphvizOnline/#digraph%20%7B%0A%09compound%20%3D%20%22true%22%0A%09newrank%20%3D%20%22true%22%0A%09subgraph%20%22root%22%20%7B%0A%09%09%22%5Broot%5D%20aws_instance.ibrah-useast-1a%22%20%5Blabel%20%3D%20%22aws_instance.ibrah-useast-1a%22%2C%20shape%20%3D%20%22box%22%5D%0A%09%09%22%5Broot%5D%20aws_security_group.webserver%22%20%5Blabel%20%3D%20%22aws_security_group.webserver%22%2C%20shape%20%3D%20%22box%22%5D%0A%09%09%22%5Broot%5D%20provider.aws%22%20%5Blabel%20%3D%20%22provider.aws%22%2C%20shape%20%3D%20%22diamond%22%5D%0A%09%09%22%5Broot%5D%20aws_instance.ibrah-useast-1a%22%20-%3E%20%22%5Broot%5D%20aws_security_group.webserver%22%0A%09%09%22%5Broot%5D%20aws_security_group.webserver%22%20-%3E%20%22%5Broot%5D%20provider.aws%22%0A%09%09%22%5Broot%5D%20meta.count-boundary%20(EachMode%20fixup)%22%20-%3E%20%22%5Broot%5D%20aws_instance.ibrah-useast-1a%22%0A%09%09%22%5Broot%5D%20provider.aws%20(close)%22%20-%3E%20%22%5Broot%5D%20aws_instance.ibrah-useast-1a%22%0A%09%09%22%5Broot%5D%20root%22%20-%3E%20%22%5Broot%5D%20meta.count-boundary%20(EachMode%20fixup)%22%0A%09%09%22%5Broot%5D%20root%22%20-%3E%20%22%5Broot%5D%20provider.aws%20(close)%22%0A%09%7D%0A%7D
```